### PR TITLE
fix: 메인 화면 api 성능 향상

### DIFF
--- a/src/main/java/com/example/amattang/domain/checkList/CheckList.java
+++ b/src/main/java/com/example/amattang/domain/checkList/CheckList.java
@@ -8,7 +8,10 @@ import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -64,10 +67,4 @@ public class CheckList {
         this.pinned = pinned;
     }
 
-    public boolean isGetAnswer() {
-        Optional<ListToQuestion> isAnswer = this.listCommonQuestion.stream()
-                .filter(x -> x.getQuestionToAnswer() != null)
-                .findFirst();
-        return isAnswer.isPresent();
-    }
 }

--- a/src/main/java/com/example/amattang/domain/checkList/CheckListRepository.java
+++ b/src/main/java/com/example/amattang/domain/checkList/CheckListRepository.java
@@ -1,6 +1,15 @@
 package com.example.amattang.domain.checkList;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CheckListRepository extends JpaRepository<CheckList, Long> {
+
+    @Query("select c from CheckList c where exists (" +
+            "select m from QuestionToAnswer m where m.listToQuestion.checkListId.id=c.id and c.user.id=:userId)" +
+            "order by c.id desc")
+    List<CheckList> findAllIfAnswerExistsByUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/example/amattang/service/CheckListService.java
+++ b/src/main/java/com/example/amattang/service/CheckListService.java
@@ -6,9 +6,6 @@ import com.example.amattang.domain.commonQuestion.CommonQuestion;
 import com.example.amattang.domain.commonQuestion.CommonQuestionRepository;
 import com.example.amattang.domain.listToQuestion.ListToQuestion;
 import com.example.amattang.domain.user.User;
-import com.example.amattang.exception.ExceptionMessage;
-import com.example.amattang.payload.reponse.CommonCheckListDto;
-import com.example.amattang.payload.reponse.CommonQuestionDto;
 import com.example.amattang.payload.reponse.MainViewCheckListResponseDto;
 import com.example.amattang.payload.request.CheckListChangePinRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +13,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.example.amattang.domain.commonQuestion.CommonQuestion.MAIN_CATEGORY.BASIC;
 import static com.example.amattang.exception.ExceptionMessage.NOT_EXIST_CHECK_LIST;
 
 @Slf4j
@@ -35,11 +30,8 @@ public class CheckListService {
 
     //체크리스트 반환, 답변이 없는 체크리스트 제외
     public List<MainViewCheckListResponseDto> getAllCheckListWithAnswer(User user) {
-        List<CheckList> checkLists = user.getCheckLists().stream()
-                .filter(x -> x.isGetAnswer() == true)
-                .collect(Collectors.toList());
-        Collections.sort(checkLists, (a,b) -> (a.getId().compareTo(b.getId())) * (-1));
 
+        List<CheckList> checkLists = checkListRepository.findAllIfAnswerExistsByUserId(user.getId());
         List<MainViewCheckListResponseDto> list = IntStream.range(0, checkLists.size())
                 .mapToObj(x -> MainViewCheckListResponseDto.fromEntity(checkLists.get(x), x))
                 .collect(Collectors.toList());


### PR DESCRIPTION
메인 화면 조회 시, api 요청 시간이 너무 길어서 코드 수정
전체 체크리스트 조회 + 답변 있는 것만 필터링
-> 쿼리 수정하여 답변 있는 체크리스트만 조회